### PR TITLE
Fixed typographical error, changed admitedly to admittedly in README.

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -17,7 +17,7 @@ dynamically generate machine code. Perl's bytecode is fast, of course, but for
 certain numerical work, this can lead to operations that are orders of magnitude
 faster.
 
-(Though, admitedly, I don't yet have the benchmarks to prove my point.)
+(Though, admittedly, I don't yet have the benchmarks to prove my point.)
 
 =head1 INSTALLATION
 


### PR DESCRIPTION
@run4flat, I've corrected a typographical error in the documentation of the [C-TinyCompiler](https://github.com/run4flat/C-TinyCompiler) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
